### PR TITLE
bug fix in helper which breaks device support

### DIFF
--- a/UsbSerialForAndroid.Net/Helper/UsbManagerHelper.cs
+++ b/UsbSerialForAndroid.Net/Helper/UsbManagerHelper.cs
@@ -22,7 +22,7 @@ namespace UsbSerialForAndroid.Net.Helper
         {
             return usbManager.DeviceList?
                 .Select(c => c.Value)
-                .FirstOrDefault(c => c.VendorId == vendorId && c.VendorId == productId)
+                .FirstOrDefault(c => c.VendorId == vendorId && c.ProductId == productId)
                 ?? throw new Exception($"The corresponding device could not be found VendorId={vendorId} ProductId={productId}");
         }
         public static bool HasPermission(UsbDevice usbDevice)


### PR DESCRIPTION
I kept on getting the "The corresponding device could not be found VendorId={vendorId} ProductId={productId}" exception thrown at me for an FTDI device with vendorId 0x0403 and productId 0x6001 which confused me because it looked like it was supported. Thankfully for my own sanity it was a really easy fix. The vendorId from the device list was compared to the productId of the driver by accident when trying to get the usb device. Things seem to work fine after changing the one variable. This also addresses issue https://github.com/LUJIAN2020/UsbSerialForAndroid.Net/issues/10.