### PR TITLE
Fix BUG: FTDI driver: modem status bytes are not removed from the data stream

### DIFF
--- a/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
@@ -267,7 +267,7 @@ namespace UsbSerialForAndroid.Net.Drivers
         }
         /// <summary>
         /// Set the Latency - miliseconds
-        /// https://ftdichip.com/Support/Knowledgebase/index.html?an232b_04smalldataend.htm
+        /// https://ftdichip.com/Support/Knowledgebase/index.html?an232beffectbuffsizeandlatency.htm
         /// </summary>
         /// <param name="latency"></param>
         /// <exception cref="Exception"></exception>


### PR DESCRIPTION
- fixes [BUG: FTDI driver: modem status bytes are not removed from the data stream] (https://github.com/LUJIAN2020/UsbSerialForAndroid.Net/issues/17)
- Reduces the amount of memory allocation when copying from base UsbDriverBase.Read .ToArray()
- guaranteed return the buffer to the ArrayPool