### PR TITLE
Add Write queue, test and some fixes

### DIFF
--- a/Demo/MauiDemo/MainPage.xaml
+++ b/Demo/MauiDemo/MainPage.xaml
@@ -42,9 +42,10 @@
 
                 <StackLayout Grid.Column="0">
                     <Label Text="{x:Static rf:AppResources.BaudRate}" />
-                    <Picker x:Name="baudRatePicker">
+                    <Picker x:Name="baudRatePicker" SelectedIndex="10">
                         <Picker.ItemsSource>
                             <x:Array Type="{x:Type x:Int32}">
+                                <x:Int32>1200</x:Int32>
                                 <x:Int32>9600</x:Int32>
                                 <x:Int32>14400</x:Int32>
                                 <x:Int32>19200</x:Int32>

--- a/Demo/MauiDemo/MainPage.xaml
+++ b/Demo/MauiDemo/MainPage.xaml
@@ -154,6 +154,10 @@
             <StackLayout>
                 <Label Text="High load speed test" FontSize="20" 
                        HorizontalTextAlignment="Center" TextColor="MediumPurple"/>
+                <Grid ColumnDefinitions="50,100*">
+                    <CheckBox Grid.Column="0" IsChecked="{Binding IsEnableWrite}" VerticalOptions="Center"/>
+                    <Label Grid.Column="1" Text="Enable write" VerticalOptions="Center"/>
+                </Grid>
 
                 <Label Text="Write speed"/>
                 <Editor Text="{Binding WriteSpeed}" />

--- a/Demo/MauiDemo/MainPage.xaml.cs
+++ b/Demo/MauiDemo/MainPage.xaml.cs
@@ -8,7 +8,7 @@ namespace MauiDemo
         {
             InitializeComponent();
             BindingContext = vm;
-            baudRatePicker.SelectedIndex = 9;
+            baudRatePicker.SelectedIndex = 10;
             dataBitsPicker.SelectedIndex = 3;
             stopBitsPicker.SelectedIndex = 0;
             parityPicker.SelectedIndex = 0;

--- a/Demo/MauiDemo/Models/IOTestModel.cs
+++ b/Demo/MauiDemo/Models/IOTestModel.cs
@@ -8,14 +8,18 @@ namespace MauiDemo.Models;
 
 public partial class IOTestModel : ObservableObject
 {
-    //private UsbDriverBase? _usbDriver;
-
     public bool EnableWrite;
     [ObservableProperty] public partial string? WriteSpeed { get; set; }
     [ObservableProperty] public partial string? ReadSpeed { get; set; }
-    public IOTestModel() { }
-
+    public IOTestModel()
+    {
+        byte value = 0;
+        for (int i = 0; i < SampleBuf.Length; i++)
+            SampleBuf[i] = value++;
+    }
     public static TimeSpan UpdatePreiod = TimeSpan.FromMilliseconds(1000);
+    public const int SampleBufLength = 256;
+    public readonly byte[] SampleBuf = new byte[SampleBufLength];
 
     public async Task StartTestAsync(int deviceId, int baudRate, byte dataBits, byte stopBits, byte parity,
         CancellationToken ct)
@@ -56,14 +60,8 @@ public partial class IOTestModel : ObservableObject
             PrintErr(ex);
         }
     }
-    public const int SampleBufLength = 256;
     public async Task WriteAsync(UsbDriverBase usbDriver, CancellationToken ct)
     {
-        byte[] writeBuf = new byte[SampleBufLength];
-        // fill buf
-        for (int i = 0; i < writeBuf.Length; i++)
-            writeBuf[i] = (byte)i;
-
         double speed = 0;
         long sentTotal = 0;
         long sentPrev = 0;
@@ -81,7 +79,7 @@ public partial class IOTestModel : ObservableObject
                 tickPrev = now;
                 sentPrev = sentTotal;
             }
-            if (SampleBufLength != await usbDriver.WriteAsync(writeBuf, 0, writeBuf.Length, ct))
+            if (SampleBufLength != await usbDriver.WriteAsync(SampleBuf, 0, SampleBuf.Length, ct))
                 throw new Exception("Something write wrong");
             sentTotal += SampleBufLength;
         }
@@ -89,10 +87,6 @@ public partial class IOTestModel : ObservableObject
     private async Task ReadAsync(UsbDriverBase usbDriver, CancellationToken ct)
     {
         byte[] buf = new byte[SampleBufLength];
-        byte[] testDataSample = new byte[SampleBufLength];
-        // fill buf
-        for (int i = 0; i < testDataSample.Length; i++)
-            testDataSample[i] = (byte)i;
         double speed = 0;
         long readTotal = 0;
         long readPrev = 0;
@@ -120,22 +114,19 @@ public partial class IOTestModel : ObservableObject
                 readTotal += currReadLen;
             }
             //if (!testDataSample.SequenceEqual(buf))
-            if (!IsSeq256(buf))
-            {
-                PrintInf(BitConverter.ToString(buf));
-                PrintErr($"Read {readTotal} not equal write sequence");
-                throw new Exception($"Read {readTotal} not equal write sequence");
-            }
+            if (!IsSeq(buf))
+                throw new Exception($"Read {readTotal} not equal write sequence " +
+                    $"\n{BitConverter.ToString(buf)}");
         }
     }
-    bool IsSeq256(ReadOnlySpan<byte> s1)
+    public static bool IsSeq(ReadOnlySpan<byte> s1)
     {
-        byte prev = s1[0];
-        for (int i = 1; i < 255; i++)
+        byte val = s1[0];
+        for (int i = 1; i < s1.Length; i++)
         {
-            if (1 != s1[i] - prev)
+            val++;
+            if (val != s1[i])
                 return false;
-            prev = s1[i];
         }
         return true;
     }
@@ -143,7 +134,7 @@ public partial class IOTestModel : ObservableObject
     static void PrintErr(Exception ex) => PrintErr(ex.ToString());
     static void PrintErr(string str)
     {
-        Console.WriteLine($"[err] {str}");
+        //Console.WriteLine($"[err] {str}");
         Log.WriteLine(LogPriority.Error, "IOTest", str);
     }
     static void PrintInf(string str)

--- a/Demo/MauiDemo/Models/IOTestModel.cs
+++ b/Demo/MauiDemo/Models/IOTestModel.cs
@@ -50,6 +50,8 @@ public partial class IOTestModel : ObservableObject
     public const int SampleBufLength = 256;
     public async Task WriteAsync(UsbDriverBase usbDriver, CancellationToken ct)
     {
+        //while (!ct.IsCancellationRequested) 
+        //    await Task.Delay(10000, ct);
         byte[] writeBuf = new byte[SampleBufLength];
         // fill buf
         for (int i = 0; i < writeBuf.Length; i++)
@@ -110,13 +112,25 @@ public partial class IOTestModel : ObservableObject
                 currLen -= currReadLen;
                 readTotal += currReadLen;
             }
-            if (!testDataSample.SequenceEqual(buf))
+            //if (!testDataSample.SequenceEqual(buf))
+            if (!IsSeq256(buf))
             {
                 PrintInf(BitConverter.ToString(buf));
                 PrintErr($"Read {readTotal} not equal write sequence");
                 throw new Exception($"Read {readTotal} not equal write sequence");
             }
         }
+    }
+    bool IsSeq256(ReadOnlySpan<byte> s1)
+    {
+        byte prev = s1[0];
+        for (int i = 1; i < 255; i++)
+        {
+            if (1 != s1[i] - prev)
+                return false;
+            prev = s1[i];
+        }
+        return true;
     }
 
     static void PrintErr(Exception ex) => PrintErr(ex.ToString());

--- a/Demo/MauiDemo/Models/IOTestModel.cs
+++ b/Demo/MauiDemo/Models/IOTestModel.cs
@@ -9,6 +9,8 @@ namespace MauiDemo.Models;
 public partial class IOTestModel : ObservableObject
 {
     //private UsbDriverBase? _usbDriver;
+
+    public bool EnableWrite;
     [ObservableProperty] public partial string? WriteSpeed { get; set; }
     [ObservableProperty] public partial string? ReadSpeed { get; set; }
     public IOTestModel() { }
@@ -23,7 +25,14 @@ public partial class IOTestModel : ObservableObject
         var _parity = (UsbSerialForAndroid.Net.Enums.Parity)parity;
         await usbDriver.OpenAsync(baudRate, dataBits, _stopBits, _parity);
         await Task.Delay(100, ct);
-        await Task.WhenAny(ExecReadAsync(usbDriver, ct), ExecWriteAsync(usbDriver, ct));
+        if (EnableWrite)
+        {
+            await Task.WhenAny(ExecReadAsync(usbDriver, ct), ExecWriteAsync(usbDriver, ct));
+        }
+        else
+        {
+            await ExecReadAsync(usbDriver, ct);
+        }
     }
     public async Task ExecReadAsync(UsbDriverBase usbDriver, CancellationToken ct)
     {
@@ -50,8 +59,6 @@ public partial class IOTestModel : ObservableObject
     public const int SampleBufLength = 256;
     public async Task WriteAsync(UsbDriverBase usbDriver, CancellationToken ct)
     {
-        //while (!ct.IsCancellationRequested) 
-        //    await Task.Delay(10000, ct);
         byte[] writeBuf = new byte[SampleBufLength];
         // fill buf
         for (int i = 0; i < writeBuf.Length; i++)

--- a/Demo/MauiDemo/Models/IOTestModel.cs
+++ b/Demo/MauiDemo/Models/IOTestModel.cs
@@ -29,6 +29,7 @@ public partial class IOTestModel : ObservableObject
         var _parity = (UsbSerialForAndroid.Net.Enums.Parity)parity;
         await usbDriver.OpenAsync(baudRate, dataBits, _stopBits, _parity);
         await Task.Delay(100, ct);
+        await usbDriver.FlushAsync(ct);
         if (EnableWrite)
         {
             await Task.WhenAny(ExecReadAsync(usbDriver, ct), ExecWriteAsync(usbDriver, ct));

--- a/Demo/MauiDemo/ViewModels/MainViewModel.cs
+++ b/Demo/MauiDemo/ViewModels/MainViewModel.cs
@@ -93,6 +93,7 @@ namespace MauiDemo.ViewModels
                 ShowMessage(ex.Message);
             }
         });
+        [ObservableProperty] public partial bool? IsEnableWrite { get; set; } = true;
         [ObservableProperty] public partial string? WriteSpeed { get; set; }
         [ObservableProperty] public partial string? ReadSpeed { get; set; }
         [RelayCommand(IncludeCancelCommand = true)]
@@ -108,7 +109,7 @@ namespace MauiDemo.ViewModels
                 || items[3] is not byte stopBits
                 || items[4] is not Parity parity)
                     return;
-                var test = new IOTestModel();
+                var test = new IOTestModel() { EnableWrite = this.IsEnableWrite ?? false };
                 test.PropertyChanged += (obj, arg) =>
                 {
                     MainThread.BeginInvokeOnMainThread(() =>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ var buffer = usbDriver.Read();
 usbDriver.Close();
 ```
 
+Async version (see sample in IOTestModel.cs)
+```
+//Open the USB device and set the communication parameters
+using var usbDriver = UsbDriverFactory.CreateUsbDriver(deviceId);
+await usbDriver.OpenAsync(230400, 8, StopBits.One, Parity.None);
+//await usbDriver.FlushAsync(ct);
+
+//Send data
+var data = new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x08, 0x3D, 0xCC };
+var sentLen = await usbDriver.WriteAsync(data, 0, data.Length, ct))
+
+//Receive data
+var buf = new byte[256];
+int readedLen = await usbDriver.ReadAsync(buf, 0, buf.Length, ct);
+
+//Close the USB device - will be called automatically when Dispose usbDriver
+//usbDriver.Close();
+```
+
 ### 🚀Supported Driver
 
 **Technology Devices International, Ltd**
@@ -84,6 +103,7 @@ QinHeng = 0x1A86
 
 - HL340 = 0x7523
 - CH341A = 0x5523
+- CH9102= 0x55d4 (CDC)
 
 **Silicon Labs** 
 

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -705,8 +705,11 @@ namespace UsbSerialForAndroid.Net.Drivers
             var curr = Interlocked.Exchange(ref _current, null);
             if (curr != null)
                 await sendQueue.WriteAsync(curr, ct);
-            await foreach (var rq in _dataRqChannel.Reader.ReadAllAsync(ct))
+            while (0 < _dataRqChannel.Reader.Count)
+            {
+                var rq = await _dataRqChannel.Reader.ReadAsync(ct);
                 await sendQueue.WriteAsync(rq, ct);
+            }
             StartProcessingTasks();
         }
     }

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -124,6 +124,12 @@ namespace UsbSerialForAndroid.Net.Drivers
             OpenAsync(baudRate, dataBits, stopBits, parity).AsTask().SynchronousWait();
         public abstract ValueTask OpenAsync(int baudRate, byte dataBits, StopBits stopBits, Parity parity);
         /// <summary>
+        /// Set the Latency - miliseconds
+        /// mainly for the ftdi chip, allows you to reduce latency (chip polling interval per second)
+        /// </summary>
+        /// <param name="latency"></param>
+        public virtual void SetLatency(byte latency) {  }
+        /// <summary>
         /// Set DTR enabled
         /// </summary>
         /// <param name="value">true=enabled</param>

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -1,5 +1,5 @@
 ﻿#if DEBUG
-//#define TRACE_INFO
+#define TRACE_INFO
 #endif
 using Android.App;
 using Android.Content;
@@ -9,6 +9,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -252,14 +253,30 @@ namespace UsbSerialForAndroid.Net.Drivers
         }
         protected int UsbWriteBufLength = 256;
         protected int UsbReadBufLength = 256;
-        protected int UsbRequestCount = 64;
+        protected int UsbRequestCount = 128;
+        protected int UsbWriteRequestCount = 8;
         public const int UsbMinRequestCount = 4;
 
         public int ReadHeaderLength = 0;
-        public FilterDataFn? FilterData;
         public delegate int FilterDataFn(Span<byte> src, Span<byte> dst);
+        public FilterDataFn? FilterData;
+        private delegate void QueueRequestFn(UsbRequest usbRq, NetDirectByteBuffer buf);
+        private static readonly QueueRequestFn _queueRequest
+            = OperatingSystem.IsAndroidVersionAtLeast(26) ? QueueRequestGreater26 : QueueRequestLess26;
+        [SupportedOSPlatform("android26.0")]
+        public static void QueueRequestGreater26(UsbRequest usbRq, NetDirectByteBuffer buf)
+        {
+            if (!usbRq.Queue(buf.JavaBuffer))
+                throw new Java.IO.IOException("Error queueing request.");
+        }
+        [ObsoletedOSPlatform("android26.0")]
+        public static void QueueRequestLess26(UsbRequest usbRq, NetDirectByteBuffer buf)
+        {
+            if (!usbRq.Queue(buf.JavaBuffer, buf.JavaBuffer.Limit()))
+                throw new Java.IO.IOException("Error queueing request.");
+        }
 
-        protected UsbRequest? _usbWriteRequest;
+        protected List<UsbRequest> _writeRequests = [];
         protected List<UsbRequest> _readRequests = [];
 
         protected UsbRequest? _current = null;
@@ -271,47 +288,73 @@ namespace UsbSerialForAndroid.Net.Drivers
         Channel<UsbRequest>? _writeChannel;
         Channel<UsbRequest>? _dataRqChannel;
         Channel<UsbRequest>? _sendRqChannel;
-
+        protected static async Task<List<UsbRequest>> MakeBuffListAsync(int count, int length,
+            UsbDeviceConnection conn, UsbEndpoint endpoint, ChannelWriter<UsbRequest> channel)
+        {
+            var list = new List<UsbRequest>(count);
+            for (int i = 0; i < count; i++)
+            {
+                var rq = new UsbRequest();
+                rq.Initialize(conn, endpoint);
+                list.Add(rq);
+                rq.ClientData = new NetDirectByteBuffer(length);
+                await channel.WriteAsync(rq);
+            }
+            return list;
+        }
+        protected static async Task CloseBuffListAsync(List<UsbRequest>? list)
+        {
+            if (list is null)
+                return;
+            foreach (var item in list)
+            {
+                if (item.ClientData is NetDirectByteBuffer buf)
+                    buf.Dispose();
+                item.Cancel();
+                item.Close();
+                item.Dispose();
+            }
+        }
         protected async Task InitBuffersAsync()
         {
             TraceInfo("InitAsync");
             ArgumentNullException.ThrowIfNull(UsbDeviceConnection);
             ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
             ArgumentNullException.ThrowIfNull(UsbEndpointRead);
+            UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
+            UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
 
             // initializing a queue of free write requests
-            _usbWriteRequest = new();
-            _usbWriteRequest.Initialize(UsbDeviceConnection, UsbEndpointWrite);
-            _writeChannel = Channel.CreateBounded<UsbRequest>(new BoundedChannelOptions(1)
+            _writeChannel = Channel.CreateUnbounded<UsbRequest>(new UnboundedChannelOptions()
             {
-                SingleReader = true,
-                SingleWriter = true,
+                SingleReader = false,
+                SingleWriter = false,
                 AllowSynchronousContinuations = false,
-                FullMode = BoundedChannelFullMode.Wait
             });
-            await _writeChannel.Writer.WriteAsync(_usbWriteRequest);// just one
+            _writeRequests = await MakeBuffListAsync(UsbWriteRequestCount, UsbWriteBufLength,
+                UsbDeviceConnection, UsbEndpointWrite, _writeChannel.Writer);
+            int idx = 0;
+            foreach (var rq in _writeRequests)
+            {
+                if (rq?.ClientData is NetDirectByteBuffer buf)
+                    buf.ClientData = idx++;
+            }
             // initializing a queue of free read requests
             _sendRqChannel = Channel.CreateUnbounded<UsbRequest>(new UnboundedChannelOptions()
             {
-                SingleReader = true,
+                SingleReader = false,
                 SingleWriter = false,
                 AllowSynchronousContinuations = false
             });
             _dataRqChannel = Channel.CreateUnbounded<UsbRequest>(new UnboundedChannelOptions()
             {
                 SingleReader = false,
-                SingleWriter = true,
+                SingleWriter = false,
                 AllowSynchronousContinuations = false
             });
             // create and send to OS all read request
-            for (int i = 0; i < UsbRequestCount; i++)
-            {
-                var rq = new UsbRequest();
-                rq.Initialize(UsbDeviceConnection, UsbEndpointRead);
-                _readRequests.Add(rq);
-                rq.ClientData = new NetDirectByteBuffer(UsbReadBufLength);
-                await _sendRqChannel.Writer.WriteAsync(rq);
-            }
+            _readRequests = await MakeBuffListAsync(UsbRequestCount, UsbReadBufLength,
+                UsbDeviceConnection, UsbEndpointRead, _sendRqChannel.Writer);
             StartProcessingTasks();
             TraceInfo("InitAsync - Ok");
         }
@@ -334,15 +377,10 @@ namespace UsbSerialForAndroid.Net.Drivers
 
                 // clear requests
                 var oldReadRequests = Interlocked.Exchange(ref _readRequests, []);
-                foreach (var item in oldReadRequests)
-                {
-                    if (item.ClientData is NetDirectByteBuffer buf)
-                        buf.Dispose();
-                    item.Cancel();
-                    item.Close();
-                    item.Dispose();
-                }
-                Interlocked.Exchange(ref _usbWriteRequest, null)?.Dispose();
+                await CloseBuffListAsync(oldReadRequests);
+                // clear write requests
+                var oldWriteRequests = Interlocked.Exchange(ref _writeRequests, []);
+                await CloseBuffListAsync(oldWriteRequests);
                 TraceInfo("DeinitAsync - Ok");
             }
             catch (Exception ex)
@@ -355,6 +393,16 @@ namespace UsbSerialForAndroid.Net.Drivers
             _processUsbTasksToken = new();
             _sendTask = Task.Run(() => UsbSendAsync(_processUsbTasksToken.Token));
             _receiveTask = Task.Run(() => UsbReceiveAsync(_processUsbTasksToken.Token));
+            /*
+            _sendTask = Task.Factory.StartNew(() => UsbSendAsync(_processUsbTasksToken.Token),
+                _processUsbTasksToken.Token,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.RunContinuationsAsynchronously,
+                TaskScheduler.Default);
+            _receiveTask = Task.Factory.StartNew(() => UsbReceiveAsync(_processUsbTasksToken.Token),
+                _processUsbTasksToken.Token,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.RunContinuationsAsynchronously,
+                TaskScheduler.Default);
+            */
         }
         private void ThrowIfNotStartedOrFaulted()
         {
@@ -414,6 +462,7 @@ namespace UsbSerialForAndroid.Net.Drivers
             {
                 try
                 {
+                    TraceInfo($"wait IO (read/wite) = {_readRqCount}/{_writeRqCount}");
                     dataRq = await UsbDeviceConnection.RequestWaitAsync().WaitAsync(ct);
                 }
                 catch (Java.Lang.IllegalArgumentException iEx)
@@ -452,6 +501,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                 }
                 if (ReferenceEquals(dataRq.Endpoint, UsbEndpointRead))
                 {
+                    Interlocked.Decrement(ref _readRqCount);
                     if (ReadHeaderLength < ((NetDirectByteBuffer?)dataRq.ClientData!).Position)
                     {
                         await dataRqWriter.WriteAsync(dataRq, ct);
@@ -459,6 +509,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                         // we'll leave a reserve of UsbMinRequestCount(4) active requests in the OS queue.
                         if (UsbRequestCount - UsbMinRequestCount < _dataRqChannel.Reader.Count)
                         {
+                            TraceInfo($"no empty buffers");
                             dataRq = Interlocked.Exchange(ref _current, null);// try return current first dequeued item
                             dataRq ??= await _dataRqChannel.Reader.ReadAsync(ct);
                             await sendRqWriter.WriteAsync(dataRq, ct);
@@ -470,10 +521,19 @@ namespace UsbSerialForAndroid.Net.Drivers
                 }
                 if (ReferenceEquals(dataRq.Endpoint, UsbEndpointWrite))
                 {
+                    TraceInfo($"receive write request");
+                    Interlocked.Decrement(ref _writeRqCount);
                     await wr.WriteAsync(dataRq, ct);
+                    TraceInfo($"return write request");
                 }
             }
         }
+
+        private int _readRqCount = 0;
+        private int _writeRqCount = 0;
+        private SemaphoreSlim _writeSem = new(1, 1);
+
+
         /// <summary>
         /// receives requests
         /// , and send back to OS request queue. 
@@ -491,14 +551,22 @@ namespace UsbSerialForAndroid.Net.Drivers
                 sendRq = await sendRqReader.ReadAsync(ct);
                 if (sendRq?.ClientData is NetDirectByteBuffer buf)
                 {
+                    buf.Rewind();
                     if (ReferenceEquals(sendRq.Endpoint, UsbEndpointRead))
                     {
-                        buf.Rewind();
                         buf.ClientData = null;
+                        Interlocked.Increment(ref _readRqCount);
+                        _queueRequest(sendRq, buf);
+                        TraceInfo($"send read request");
                     }
-                    if (!(OperatingSystem.IsAndroidVersionAtLeast(26) ?
-                        sendRq.Queue(buf.JavaBuffer) : sendRq.Queue(buf.JavaBuffer, buf.JavaBuffer.Capacity())))
-                        throw new Java.IO.IOException("Error queueing request.");
+                    else
+                    {
+                        //await _writeSem.WaitAsync(ct);
+                        //await Task.Delay(1, ct);
+                        Interlocked.Increment(ref _writeRqCount);
+                        _queueRequest(sendRq, buf);
+                        TraceInfo($"send write request {buf.ClientData} len={buf.JavaBuffer.Limit()}");
+                    }
                 }
                 else
                     throw new Exception("broken emptyRq - ClientData is null or not NetDirectByteBuffer");
@@ -506,7 +574,7 @@ namespace UsbSerialForAndroid.Net.Drivers
         }
         public virtual async Task<int> ReadAsync(byte[] dstBuf, int offset, int count, CancellationToken ct = default)
         {
-            TraceInfo($"Start read count={count}");
+            TraceInfo($"Read Start expected={count}");
             ThrowIfNotStartedOrFaulted();
             ArgumentNullException.ThrowIfNull(_dataRqChannel);
             ArgumentNullException.ThrowIfNull(_sendRqChannel);
@@ -522,33 +590,32 @@ namespace UsbSerialForAndroid.Net.Drivers
                 while (!ct.IsCancellationRequested && rq?.ClientData is NetDirectByteBuffer buf)
                 {
                     var data = buf.MemBuffer.Span.Slice(0, buf.Position);
-                    TraceInfo($"data length {buf.Position}");
+                    TraceInfo($"read get buf, len={buf.Position}");
                     if (null != FilterData && buf.Position > (count - readed))
                     {
                         buf.Position = FilterData(data, data);
                         buf.ClientData = true;// filtered
                         data = buf.MemBuffer.Span.Slice(0, buf.Position);
-                        TraceInfo($"filter in buf, filtered Length={buf.Position}");
+                        TraceInfo($"read filter in buf, filtered Len={buf.Position}");
                     }
                     int currLen;
                     if (null == FilterData || buf.ClientData is true)
                     {
                         currLen = int.Min(count - readed, buf.Position);
-                        TraceInfo($"copy filtered {currLen}");
+                        TraceInfo($"read copy filtered {currLen}");
                         data.Slice(0, currLen).CopyTo(dstBuf.AsSpan(offset));
                     }
                     else
                     {
                         currLen = FilterData(data, dstBuf.AsSpan(offset));
-                        TraceInfo($"filter copy {currLen}");
+                        TraceInfo($"read filter copy {currLen}");
                     }
                     readed += currLen;
                     offset += currLen;
-                    TraceInfo($"readed={readed}");
                     if (readed == count)
                     {
                         var rest = buf.Position - currLen;
-                        TraceInfo($"rest={rest}");
+                        TraceInfo($"read REST={rest}");
                         if (0 < rest)
                         {
                             data.Slice(currLen, rest).CopyTo(data.Slice(0, rest));
@@ -569,6 +636,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                     // _emptyReader!.Count does not work on single reader
                     //TraceInfo($"[USBDRIVER]: net buf={buf} data={_dataReader.Count} , free={_emptyReader!.Count}");
                 }
+                TraceInfo($"Read End readed={count}");
                 return readed;
             }
             finally
@@ -581,6 +649,8 @@ namespace UsbSerialForAndroid.Net.Drivers
         }
         public virtual async Task<int> WriteAsync(byte[] wbuf, int offset, int count, CancellationToken ct = default)
         {
+            await _writeSem.WaitAsync(ct);
+            TraceInfo($"Write Start count={count}");
             ThrowIfNotStartedOrFaulted();
             ArgumentNullException.ThrowIfNull(_writeChannel);
             ArgumentNullException.ThrowIfNull(_sendRqChannel);
@@ -589,23 +659,43 @@ namespace UsbSerialForAndroid.Net.Drivers
             {
                 var receiveQueue = _writeChannel.Reader;
                 var sendQueue = _sendRqChannel.Writer;
-                int rest = count;
-                while (0 < rest)
+                int currentLen = 0;
+                ReadOnlyMemory<byte> src = wbuf.AsMemory(offset, count);
+                while (0 < src.Length)
                 {
                     ct.ThrowIfCancellationRequested();
                     if (null == wr && !receiveQueue.TryRead(out wr))
                         wr = await receiveQueue.ReadAsync(ct);// get a free write-request
-                    using var buf = new NetDirectByteBuffer(wbuf, offset, int.Min(rest, UsbWriteBufLength));
-                    wr.ClientData = buf;
+                    if (wr.ClientData is not NetDirectByteBuffer buf)
+                        throw new NullReferenceException(nameof(wr.ClientData));
+                    currentLen = int.Min(src.Length, UsbWriteBufLength);
+                    // TraceInfo($"Transferred {buf.JavaBuffer.Position()}/{buf.JavaBuffer.Limit()}");
+                    buf.JavaBuffer.Limit(currentLen);
+                    src.Slice(0, currentLen).CopyTo(buf.MemBuffer);
                     await sendQueue.WriteAsync(wr, ct);//send request
+
+                    //if (!_queueRequest(wr, buf))
+                    //    throw new Java.IO.IOException("Error queueing request.");
+                    //Interlocked.Increment(ref _writeRqCount);
+
                     wr = null; // here we no longer own the request 
-                    wr = await receiveQueue.ReadAsync(ct);//wait response
-                    offset += buf.Position;
-                    rest -= buf.Position;
-                    //TraceInfo($"sent {buf.Position}");
+                    src = src.Slice(currentLen);
+                    TraceInfo($"sent {count - src.Length}");
+
+                    // Zero length packet
+                    //wr = await receiveQueue.ReadAsync(ct);// get a free write-request
+                    //if (wr.ClientData is NetDirectByteBuffer ebuf)
+                    //{
+                    //    ebuf.JavaBuffer.Rewind();
+                    //    ebuf.JavaBuffer.Limit(0);
+                    //    await sendQueue.WriteAsync(wr, ct);//send request
+                    //}
+                    //wr = null;
+
+                    //await Task.Delay(10, ct);
+                    //await Task.Yield();
                 }
-                TraceInfo($"sent total {count - rest}");
-                return count - rest;
+                return count - src.Length;
             }
             catch (OperationCanceledException)
             {
@@ -625,6 +715,9 @@ namespace UsbSerialForAndroid.Net.Drivers
                     // or upon completion of sending
                     await _writeChannel.Writer.WriteAsync(wr, CancellationToken.None);
                 }
+                TraceInfo($"total sent {count}");
+                //await Task.Delay(10000, ct);
+                _writeSem.Release();
             }
         }
         public async Task FlushAsync(CancellationToken ct = default)

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -316,14 +316,25 @@ namespace UsbSerialForAndroid.Net.Drivers
                 item.Dispose();
             }
         }
-        protected async Task InitBuffersAsync()
+        protected async Task InitBuffersAsync(int baudRate, byte dataBits, StopBits stopBits, Parity parity)
         {
             TraceInfo("InitAsync");
             ArgumentNullException.ThrowIfNull(UsbDeviceConnection);
             ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
             ArgumentNullException.ThrowIfNull(UsbEndpointRead);
-            //UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
-            //UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
+            if (9600 > baudRate)
+            {
+                UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
+                UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
+            }
+            // Let's set the number of read buffers to last for about 0.5 seconds
+            // 921600 / 10 / 256 * 0.5 = 180
+            // 460800 / 10 / 256 * 0.5 = 90
+            // 115200 / 10 / 256 * 0.5 = 22.5
+            // 9600 / 10 / 64 * 0.5 = 7.5
+            // 1200 / 10 / 64 * 0.5 = 0.9375
+            UsbRequestCount = int.Min(512, int.Max(32, (int)(baudRate / 10d / UsbReadBufLength * 0.5)));
+            //UsbWriteRequestCount = int.Min(8, int.Max(1, (int)(baudRate / 9600)));
 
             // initializing a queue of free write requests
             _writeChannel = Channel.CreateUnbounded<UsbRequest>(new UnboundedChannelOptions()

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -254,7 +254,7 @@ namespace UsbSerialForAndroid.Net.Drivers
         protected int UsbWriteBufLength = 256;
         protected int UsbReadBufLength = 256;
         protected int UsbRequestCount = 128;
-        protected int UsbWriteRequestCount = 8;
+        protected int UsbWriteRequestCount = 32;
         public const int UsbMinRequestCount = 4;
 
         public int ReadHeaderLength = 0;
@@ -308,6 +308,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                 return;
             foreach (var item in list)
             {
+                item.Cancel();
                 if (item.ClientData is NetDirectByteBuffer buf)
                     buf.Dispose();
                 item.Cancel();
@@ -462,7 +463,7 @@ namespace UsbSerialForAndroid.Net.Drivers
             {
                 try
                 {
-                    TraceInfo($"wait IO (read/wite) = {_readRqCount}/{_writeRqCount}");
+                    //TraceInfo($"wait IO (read/wite) = {_readRqCount}/{_writeRqCount}");
                     dataRq = await UsbDeviceConnection.RequestWaitAsync().WaitAsync(ct);
                 }
                 catch (Java.Lang.IllegalArgumentException iEx)
@@ -501,7 +502,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                 }
                 if (ReferenceEquals(dataRq.Endpoint, UsbEndpointRead))
                 {
-                    Interlocked.Decrement(ref _readRqCount);
+                    //Interlocked.Decrement(ref _readRqCount);
                     if (ReadHeaderLength < ((NetDirectByteBuffer?)dataRq.ClientData!).Position)
                     {
                         await dataRqWriter.WriteAsync(dataRq, ct);
@@ -521,18 +522,14 @@ namespace UsbSerialForAndroid.Net.Drivers
                 }
                 if (ReferenceEquals(dataRq.Endpoint, UsbEndpointWrite))
                 {
-                    TraceInfo($"receive write request");
-                    Interlocked.Decrement(ref _writeRqCount);
+                    //Interlocked.Decrement(ref _writeRqCount);
                     await wr.WriteAsync(dataRq, ct);
-                    TraceInfo($"return write request");
                 }
             }
         }
 
-        private int _readRqCount = 0;
-        private int _writeRqCount = 0;
-        private SemaphoreSlim _writeSem = new(1, 1);
-
+        //private int _readRqCount = 0;
+        //private int _writeRqCount = 0;
 
         /// <summary>
         /// receives requests
@@ -555,15 +552,13 @@ namespace UsbSerialForAndroid.Net.Drivers
                     if (ReferenceEquals(sendRq.Endpoint, UsbEndpointRead))
                     {
                         buf.ClientData = null;
-                        Interlocked.Increment(ref _readRqCount);
+                        //Interlocked.Increment(ref _readRqCount);
                         _queueRequest(sendRq, buf);
                         TraceInfo($"send read request");
                     }
                     else
                     {
-                        //await _writeSem.WaitAsync(ct);
-                        //await Task.Delay(1, ct);
-                        Interlocked.Increment(ref _writeRqCount);
+                        //Interlocked.Increment(ref _writeRqCount);
                         _queueRequest(sendRq, buf);
                         TraceInfo($"send write request {buf.ClientData} len={buf.JavaBuffer.Limit()}");
                     }
@@ -636,7 +631,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                     // _emptyReader!.Count does not work on single reader
                     //TraceInfo($"[USBDRIVER]: net buf={buf} data={_dataReader.Count} , free={_emptyReader!.Count}");
                 }
-                TraceInfo($"Read End readed={count}");
+                TraceInfo($"Read End readed/expected = {readed}/{count}");
                 return readed;
             }
             finally
@@ -649,7 +644,6 @@ namespace UsbSerialForAndroid.Net.Drivers
         }
         public virtual async Task<int> WriteAsync(byte[] wbuf, int offset, int count, CancellationToken ct = default)
         {
-            await _writeSem.WaitAsync(ct);
             TraceInfo($"Write Start count={count}");
             ThrowIfNotStartedOrFaulted();
             ArgumentNullException.ThrowIfNull(_writeChannel);
@@ -673,27 +667,9 @@ namespace UsbSerialForAndroid.Net.Drivers
                     buf.JavaBuffer.Limit(currentLen);
                     src.Slice(0, currentLen).CopyTo(buf.MemBuffer);
                     await sendQueue.WriteAsync(wr, ct);//send request
-
-                    //if (!_queueRequest(wr, buf))
-                    //    throw new Java.IO.IOException("Error queueing request.");
-                    //Interlocked.Increment(ref _writeRqCount);
-
                     wr = null; // here we no longer own the request 
                     src = src.Slice(currentLen);
                     TraceInfo($"sent {count - src.Length}");
-
-                    // Zero length packet
-                    //wr = await receiveQueue.ReadAsync(ct);// get a free write-request
-                    //if (wr.ClientData is NetDirectByteBuffer ebuf)
-                    //{
-                    //    ebuf.JavaBuffer.Rewind();
-                    //    ebuf.JavaBuffer.Limit(0);
-                    //    await sendQueue.WriteAsync(wr, ct);//send request
-                    //}
-                    //wr = null;
-
-                    //await Task.Delay(10, ct);
-                    //await Task.Yield();
                 }
                 return count - src.Length;
             }
@@ -716,8 +692,6 @@ namespace UsbSerialForAndroid.Net.Drivers
                     await _writeChannel.Writer.WriteAsync(wr, CancellationToken.None);
                 }
                 TraceInfo($"total sent {count}");
-                //await Task.Delay(10000, ct);
-                _writeSem.Release();
             }
         }
         public async Task FlushAsync(CancellationToken ct = default)

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -1,5 +1,5 @@
 ﻿#if DEBUG
-#define TRACE_INFO
+//#define TRACE_INFO
 #endif
 using Android.App;
 using Android.Content;

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -254,7 +254,7 @@ namespace UsbSerialForAndroid.Net.Drivers
         protected int UsbWriteBufLength = 256;
         protected int UsbReadBufLength = 256;
         protected int UsbRequestCount = 128;
-        protected int UsbWriteRequestCount = 32;
+        protected int UsbWriteRequestCount = 8;
         public const int UsbMinRequestCount = 4;
 
         public int ReadHeaderLength = 0;
@@ -322,8 +322,8 @@ namespace UsbSerialForAndroid.Net.Drivers
             ArgumentNullException.ThrowIfNull(UsbDeviceConnection);
             ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
             ArgumentNullException.ThrowIfNull(UsbEndpointRead);
-            UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
-            UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
+            //UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
+            //UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
 
             // initializing a queue of free write requests
             _writeChannel = Channel.CreateUnbounded<UsbRequest>(new UnboundedChannelOptions()
@@ -554,13 +554,13 @@ namespace UsbSerialForAndroid.Net.Drivers
                         buf.ClientData = null;
                         //Interlocked.Increment(ref _readRqCount);
                         _queueRequest(sendRq, buf);
-                        TraceInfo($"send read request");
+                        //TraceInfo($"send read request");
                     }
                     else
                     {
                         //Interlocked.Increment(ref _writeRqCount);
                         _queueRequest(sendRq, buf);
-                        TraceInfo($"send write request {buf.ClientData} len={buf.JavaBuffer.Limit()}");
+                        //TraceInfo($"send write request {buf.ClientData} len={buf.JavaBuffer.Limit()}");
                     }
                 }
                 else

--- a/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
+++ b/UsbSerialForAndroid.Net/Drivers/Base/UsbDriverBase.cs
@@ -586,7 +586,9 @@ namespace UsbSerialForAndroid.Net.Drivers
                 {
                     var data = buf.MemBuffer.Span.Slice(0, buf.Position);
                     TraceInfo($"read get buf, len={buf.Position}");
-                    if (null != FilterData && buf.Position > (count - readed))
+                    if (null != FilterData
+                        && (buf.ClientData is null || buf.ClientData is false)
+                        && buf.Position > (count - readed))
                     {
                         buf.Position = FilterData(data, data);
                         buf.ClientData = true;// filtered

--- a/UsbSerialForAndroid.Net/Drivers/CdcAcmSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/CdcAcmSerialDriver.cs
@@ -32,7 +32,7 @@ namespace UsbSerialForAndroid.Net.Drivers
                 OpenInterface();
             }
             SetParameters(baudRate, dataBits, stopBits, parity);
-            await InitBuffersAsync();
+            await InitBuffersAsync(baudRate, dataBits, stopBits, parity);
         }
         private void OpenSingleInterface()
         {

--- a/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
@@ -79,15 +79,12 @@ namespace UsbSerialForAndroid.Net.Drivers
             // 1000 / 921600 / 10 *256 = 2.7msec
             // 1000 / 460800 / 10 *256 = 5.5msec
             uint latency = (uint)(1000d / (baudRate / 10d) * 256d + 0.5d);
-            latency = uint.Max(1, latency);
-            latency = uint.Min(32, latency);
-            UsbRequestCount = (1 == latency) ? 256 : 128;
-            UsbWriteRequestCount = 2;
+            latency = uint.Min(32, uint.Max(1, latency));
 
             SetParameter(baudRate, dataBits, stopBits, parity);
             SetLatency((byte)latency);
             FilterData = FilterBuf;
-            await InitBuffersAsync();
+            await InitBuffersAsync(baudRate, dataBits, stopBits, parity);
         }
         /// <summary>
         /// Reset the USB device

--- a/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
@@ -283,7 +283,7 @@ namespace UsbSerialForAndroid.Net.Drivers
         /// <param name="latency"></param>
         /// <exception cref="Exception"></exception>
         /// <exception cref="ControlTransferException"></exception>
-        public void SetLatency(byte latency)
+        public override void SetLatency(byte latency)
         {
             ArgumentNullException.ThrowIfNull(UsbDeviceConnection);
             int config = latency;

--- a/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
@@ -78,10 +78,10 @@ namespace UsbSerialForAndroid.Net.Drivers
             // 1000 / 2000000 / 10 *256 = 1.28
             // 1000 / 921600 / 10 *256 = 2.7msec
             // 1000 / 460800 / 10 *256 = 5.5msec
-            uint latency = (uint)(1000d / (baudRate / 10d) * 256d);
+            uint latency = (uint)(1000d / (baudRate / 10d) * 256d + 0.5d);
             latency = uint.Max(1, latency);
             latency = uint.Min(32, latency);
-            UsbRequestCount = (1 == latency)? 256 : 128;
+            UsbRequestCount = (1 == latency) ? 256 : 128;
             UsbWriteRequestCount = 2;
 
             SetParameter(baudRate, dataBits, stopBits, parity);

--- a/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/FtdiSerialDriver.cs
@@ -74,8 +74,18 @@ namespace UsbSerialForAndroid.Net.Drivers
                 || deviceType == 9// ...H devices                                                        
                 || UsbDevice.InterfaceCount > 1;// FT2232C
 
+            // adjust latency for maximum fill aggregated buffer (256 bytes)
+            // 1000 / 2000000 / 10 *256 = 1.28
+            // 1000 / 921600 / 10 *256 = 2.7msec
+            // 1000 / 460800 / 10 *256 = 5.5msec
+            uint latency = (uint)(1000d / (baudRate / 10d) * 256d);
+            latency = uint.Max(1, latency);
+            latency = uint.Min(32, latency);
+            UsbRequestCount = (1 == latency)? 256 : 128;
+            UsbWriteRequestCount = 2;
+
             SetParameter(baudRate, dataBits, stopBits, parity);
-            SetLatency(1);
+            SetLatency((byte)latency);
             FilterData = FilterBuf;
             await InitBuffersAsync();
         }

--- a/UsbSerialForAndroid.Net/Drivers/ProlificSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/ProlificSerialDriver.cs
@@ -129,7 +129,7 @@ namespace UsbSerialForAndroid.Net.Drivers
             SetFlowControl(FlowControl);
 
             SetParameter(baudRate, dataBits, stopBits, parity);
-            await InitBuffersAsync();
+            await InitBuffersAsync(baudRate, dataBits, stopBits, parity);
         }
         public override Task CloseAsync(List<Exception>? errors = null)
         {

--- a/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
@@ -83,12 +83,6 @@ namespace UsbSerialForAndroid.Net.Drivers
             }
             Initialize();
             SetParameter(baudRate, dataBits, stopBits, parity);
-            //ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
-            //ArgumentNullException.ThrowIfNull(UsbEndpointRead);
-            //UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
-            //UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
-            //UsbRequestCount = 128;
-            //UsbWriteRequestCount = 1;
             await InitBuffersAsync();
         }
         /// <summary>

--- a/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
@@ -83,11 +83,12 @@ namespace UsbSerialForAndroid.Net.Drivers
             }
             Initialize();
             SetParameter(baudRate, dataBits, stopBits, parity);
-            ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
-            ArgumentNullException.ThrowIfNull(UsbEndpointRead);
-            UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
-            UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
-            UsbRequestCount = 128;
+            //ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
+            //ArgumentNullException.ThrowIfNull(UsbEndpointRead);
+            //UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
+            //UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
+            //UsbRequestCount = 128;
+            //UsbWriteRequestCount = 1;
             await InitBuffersAsync();
         }
         /// <summary>
@@ -101,8 +102,8 @@ namespace UsbSerialForAndroid.Net.Drivers
             ChipVersion = data[0];
             ControlOut("init #2", CH341_REQ_SERIAL_INIT, 0, 0);
             SetBaudRate(DefaultBaudRate);
-            CheckState("init #4", CH341_REQ_READ_REG, 0x2518, [0xFF /* 0x56, c3*/, 0x00]);
-            ControlOut("init #5", CH341_REQ_WRITE_REG, 0x2518, 0x0050);
+            CheckState("init #4", CH341_REQ_READ_REG, CH341_REG_LCR | (CH341_REG_LCR2 << 8), [0xFF /* 0x56, c3*/, 0x00]);
+            ControlOut("init #5", CH341_REQ_WRITE_REG, CH341_REG_LCR | (CH341_REG_LCR2 << 8), 0x0050);
             CheckState("init #6", CH341_REQ_READ_REG, 0x0706, [0xFF /*0xf?*/, 0xFF /*0xec,0xee*/]);
             ControlOut("init #7", CH341_REQ_SERIAL_INIT, 0x501f, 0xd90a);
             SetBaudRate(DefaultBaudRate);

--- a/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
@@ -88,14 +88,11 @@ namespace UsbSerialForAndroid.Net.Drivers
             // As far as I know, the polling for USB fullspeed is 1ms.
             // So 1ms * 32bytes = 32000 bytes/sec = 32000 * (10 - 2) = 256000 baud!
             // 256000 baud - this is the maximum speed, without data loss (buffer overwriting) :-(
-            // 
             ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
             ArgumentNullException.ThrowIfNull(UsbEndpointRead);
             UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
             UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
-            //UsbRequestCount = 128;
-            //UsbWriteRequestCount = 1;
-            await InitBuffersAsync();
+            await InitBuffersAsync(baudRate, dataBits, stopBits, parity);
         }
         /// <summary>
         /// Initialize the device

--- a/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/QinHengSerialDriver.cs
@@ -83,6 +83,18 @@ namespace UsbSerialForAndroid.Net.Drivers
             }
             Initialize();
             SetParameter(baudRate, dataBits, stopBits, parity);
+            // For some reason, packet aggregation does not work in ch340,
+            // i.e. if the buffer is more than 32 bytes, then the USB stack accumulates data until the buffer is full,
+            // As far as I know, the polling for USB fullspeed is 1ms.
+            // So 1ms * 32bytes = 32000 bytes/sec = 32000 * (10 - 2) = 256000 baud!
+            // 256000 baud - this is the maximum speed, without data loss (buffer overwriting) :-(
+            // 
+            ArgumentNullException.ThrowIfNull(UsbEndpointWrite);
+            ArgumentNullException.ThrowIfNull(UsbEndpointRead);
+            UsbWriteBufLength = UsbEndpointWrite.MaxPacketSize;
+            UsbReadBufLength = UsbEndpointRead.MaxPacketSize;
+            //UsbRequestCount = 128;
+            //UsbWriteRequestCount = 1;
             await InitBuffersAsync();
         }
         /// <summary>

--- a/UsbSerialForAndroid.Net/Drivers/SiliconLabsSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/SiliconLabsSerialDriver.cs
@@ -76,8 +76,8 @@ namespace UsbSerialForAndroid.Net.Drivers
         /// </summary>
         public override Task CloseAsync(List<Exception>? errors = null)
         {
-            PurgeHwBuffers(true, true);
             SetConfigSingle(SilabserIcfEnableRquestCode, UartDisable);
+            PurgeHwBuffers(true, true);
             return base.CloseAsync(errors);
         }
         /// <summary>

--- a/UsbSerialForAndroid.Net/Drivers/SiliconLabsSerialDriver.cs
+++ b/UsbSerialForAndroid.Net/Drivers/SiliconLabsSerialDriver.cs
@@ -69,7 +69,7 @@ namespace UsbSerialForAndroid.Net.Drivers
             SetConfigSingle(SilabserSetMhsRequestCode, McrAll | ControlDtrDisable | ControlRtsDisable);
             //SetConfigSingle(SilabserSetBauddivRequestCode, BaudRateGenFreq / DefaultBaudRate);
             SetParameter(baudRate, dataBits, stopBits, parity);
-            await InitBuffersAsync();
+            await InitBuffersAsync(baudRate, dataBits, stopBits, parity);
         }
         /// <summary>
         /// close port


### PR DESCRIPTION
The main purpose of this pull request is buffering for write, which is important for old (slow) devices.
Added automatic calculation of the number of required buffers, delays depending on the speed.
All corrections were made two months ago. I decided to check and test them in my application. No comments were received - sems ok.
Interesting note: cp2102 works faster than in Windows - less delays. :-)